### PR TITLE
feat: enhance UI polish, add system volume control, and fix duplicae notifications

### DIFF
--- a/NothingBar.xcodeproj/project.pbxproj
+++ b/NothingBar.xcodeproj/project.pbxproj
@@ -317,7 +317,7 @@
 				AUTOMATION_APPLE_EVENTS = NO;
 				CODE_SIGN_ENTITLEMENTS = NothingBar/NothingBar.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-			"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 21;

--- a/NothingBar.xcodeproj/project.pbxproj
+++ b/NothingBar.xcodeproj/project.pbxproj
@@ -317,7 +317,7 @@
 				AUTOMATION_APPLE_EVENTS = NO;
 				CODE_SIGN_ENTITLEMENTS = NothingBar/NothingBar.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+			"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 21;

--- a/NothingBar/Components/BatteryView.swift
+++ b/NothingBar/Components/BatteryView.swift
@@ -15,22 +15,29 @@ struct BatteryView: View {
     var body: some View {
         switch battery {
             case .budsWithCase(let `case`, let leftBud, let rightBud):
-                HStack(spacing: 2) {
+                VStack(alignment: .leading, spacing: 3) {
                     if `case`.isConnected {
-                        Text("C")
-                        levelView(for: `case`, isCompact: true)
-                            .padding(.trailing, 4)
+                        HStack(spacing: 4) {
+                            Text("Case")
+                                .foregroundColor(.secondary)
+                            levelView(for: `case`, isCompact: true)
+                        }
                     }
 
                     if leftBud.isConnected {
-                        Text("L")
-                        levelView(for: leftBud, isCompact: true)
-                            .padding(.trailing, 4)
+                        HStack(spacing: 4) {
+                            Text("Left")
+                                .foregroundColor(.secondary)
+                            levelView(for: leftBud, isCompact: true)
+                        }
                     }
 
                     if rightBud.isConnected {
-                        Text("R")
-                        levelView(for: rightBud, isCompact: true)
+                        HStack(spacing: 4) {
+                            Text("Right")
+                                .foregroundColor(.secondary)
+                            levelView(for: rightBud, isCompact: true)
+                        }
                     }
                 }
                 .font(.caption2)

--- a/NothingBar/Components/DeviceImageView.swift
+++ b/NothingBar/Components/DeviceImageView.swift
@@ -15,7 +15,7 @@ struct DeviceImageView: View {
     var body: some View {
         switch deviceImage {
             case let .buds(left, right):
-                HStack(spacing: 6) {
+                HStack(spacing: 2) {
                     imageView(left)
                     imageView(right)
                 }

--- a/NothingBar/Components/ModeCircleView.swift
+++ b/NothingBar/Components/ModeCircleView.swift
@@ -50,6 +50,7 @@ struct ModeCircleView<Overlay: View>: View {
             .frame(width: 70)
         }
         .buttonStyle(PlainButtonStyle())
+        .focusable(false)
     }
 
     private var circleView: some View {

--- a/NothingBar/Features/Bar/BarHeaderView.swift
+++ b/NothingBar/Features/Bar/BarHeaderView.swift
@@ -18,10 +18,9 @@ struct BarHeaderView: View {
     }
 
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: 12) {
             if let deviceImage = deviceState.model?.deviceImage {
-                DeviceImageView(deviceImage: deviceImage)
-                    .frame(height: 32)
+                deviceImageWithBattery(deviceImage)
             } else {
                 Image(systemName: "headphones")
                     .font(.system(size: 24))
@@ -37,17 +36,99 @@ struct BarHeaderView: View {
         .padding(.horizontal, 4)
     }
 
+    @ViewBuilder
+    private func deviceImageWithBattery(_ deviceImage: DeviceModel.DeviceImage) -> some View {
+        switch deviceImage {
+            case let .buds(left, right):
+                VStack(spacing: 8) {
+                    // Case battery if available
+                    if let battery = deviceState.battery, case .budsWithCase(let caseBattery, _, _) = battery, caseBattery.isConnected {
+                        HStack {
+                            Spacer()
+                            Text("Case: \(caseBattery.level)%")
+                                .font(.caption2)
+                                .foregroundColor(.secondary)
+                            Spacer()
+                        }
+                    }
+                    
+                    // Earbud images and their batteries
+                    HStack(spacing: 4) {
+                        VStack(spacing: 2) {
+                            Image(left)
+                                .resizable()
+                                .interpolation(.high)
+                                .aspectRatio(contentMode: .fit)
+                                .frame(height: 32)
+                            
+                            if let battery = deviceState.battery {
+                                batteryLabel(for: battery, bud: "left")
+                            }
+                        }
+                        
+                        VStack(spacing: 2) {
+                            Image(right)
+                                .resizable()
+                                .interpolation(.high)
+                                .aspectRatio(contentMode: .fit)
+                                .frame(height: 32)
+                            
+                            if let battery = deviceState.battery {
+                                batteryLabel(for: battery, bud: "right")
+                            }
+                        }
+                    }
+                }
+            case let .single(image):
+                VStack(spacing: 2) {
+                    Image(image)
+                        .resizable()
+                        .interpolation(.high)
+                        .aspectRatio(contentMode: .fit)
+                        .frame(height: 32)
+                    
+                    if let battery = deviceState.battery {
+                        batteryLabel(for: battery, bud: nil)
+                    }
+                }
+        }
+    }
+
+    @ViewBuilder
+    private func batteryLabel(for battery: Battery, bud: String?) -> some View {
+        switch (battery, bud) {
+            case (.budsWithCase(_, let leftBud, let rightBud), "left"):
+                if leftBud.isConnected {
+                    Text("\(leftBud.level)%")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            case (.budsWithCase(_, let leftBud, let rightBud), "right"):
+                if rightBud.isConnected {
+                    Text("\(rightBud.level)%")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            case (.single(let singleBattery), nil):
+                if singleBattery.isConnected {
+                    Text("\(singleBattery.level)%")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            default:
+                EmptyView()
+        }
+    }
+
     private var titleView: some View {
         VStack(alignment: .leading, spacing: 2) {
             Text(deviceState.model?.displayName ?? "Unknown")
                 .font(.headline)
                 .foregroundColor(.primary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
 
-            if deviceState.isConnected {
-                if let battery = deviceState.battery {
-                    BatteryView(battery: battery)
-                }
-            } else {
+            if !deviceState.isConnected {
                 Text("Disconnected")
                     .font(.subheadline)
                     .foregroundColor(.secondary)

--- a/NothingBar/Features/Bar/BarSettingsButton.swift
+++ b/NothingBar/Features/Bar/BarSettingsButton.swift
@@ -30,6 +30,7 @@ struct BarSettingsButton: View {
             }
         }
         .buttonStyle(HoverButtonStyle())
+        .focusable(false)
         .help("Settings")
         .contextMenu {
             Button {

--- a/NothingBar/Features/Bar/Capabilities/BarAudioEQView.swift
+++ b/NothingBar/Features/Bar/Capabilities/BarAudioEQView.swift
@@ -54,18 +54,6 @@ struct BarAudioEQView: View {
         .animation(.easeInOut, value: deviceState.eqPresetCustom)
     }
 
-    private var header: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text("Equalizer")
-                .font(.subheadline)
-                .foregroundColor(.primary)
-
-            eqPresetMenu(currentPreset: deviceState.eqPreset ?? .balanced)
-                .fixedSize()
-                .padding(.leading, -4)
-        }
-    }
-
     private var eqCustomControls: some View {
         VStack(alignment: .trailing, spacing: 8) {
             HStack(spacing: 8) {
@@ -182,6 +170,7 @@ struct BarAudioEQView: View {
                 } label: {
                     Text(preset.displayName) + (currentPreset == preset ? Text(" ") + Text(Image(systemName: "checkmark")) : Text(""))
                 }
+                .focusable(false)
             }
         } label: {
             Text(deviceState.eqPreset?.displayName ?? "Unknown")
@@ -189,6 +178,7 @@ struct BarAudioEQView: View {
                 .foregroundColor(.secondary)
         }
         .menuStyle(BorderlessButtonMenuStyle())
+        .focusable(false)
     }
 
     private var supportedEqPresets: [EQPreset] {

--- a/NothingBar/Features/Bar/Capabilities/BarAudioView.swift
+++ b/NothingBar/Features/Bar/Capabilities/BarAudioView.swift
@@ -22,6 +22,8 @@ struct BarAudioView: View {
 
     var body: some View {
         VStack(spacing: 12) {
+            volumeView
+            
             if let model = deviceState.model, model.supportsEnhancedBass {
                 enhancedBassView
                     .disabled(deviceState.enhancedBass == nil)
@@ -32,66 +34,85 @@ struct BarAudioView: View {
         }
     }
 
-    // MARK: Enhanced Bass
+    // MARK: Volume Control
+
+    private var volumeView: some View {
+        BarSectionView(
+            title: "Volume",
+            value: volumeValue
+        ) {
+            HStack(spacing: 8) {
+                Image(systemName: "speaker.fill")
+                    .font(.system(size: 12))
+                    .foregroundColor(.secondary)
+                
+                Slider(
+                    value: Binding(
+                        get: { appData.systemVolumeController.volume },
+                        set: { appData.systemVolumeController.volume = $0 }
+                    ),
+                    in: 0...1,
+                    step: 0.01
+                )
+                .tint(.accentColor)
+                
+                Image(systemName: "speaker.wave.3")
+                    .font(.system(size: 12))
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+    
+    private var volumeValue: String {
+        "\(Int(appData.systemVolumeController.volume * 100))%"
+    }
 
     private var enhancedBassView: some View {
-        HStack {
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Bass Enhancement")
-                    .font(.subheadline)
-                    .foregroundColor(.primary)
-
-                if let enhancedBass = deviceState.enhancedBass, enhancedBass.isEnabled {
-                    enhancedBassMenu(currentLevel: enhancedBass.level)
-                        .fixedSize()
-                        .padding(.leading, -4)
-                } else {
+        BarSectionView(
+            title: bassTitle,
+            value: enhancedBassValue
+        ) {
+            VStack(alignment: .center, spacing: 8) {
+                HStack(spacing: 8) {
                     Text("Off")
-                        .font(.footnote)
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                    
+                    Slider(
+                        value: .init(
+                            get: {
+                                Double(deviceState.enhancedBass?.isEnabled ?? false ? deviceState.enhancedBass?.level ?? 1 : 0)
+                            },
+                            set: { newValue in
+                                let level = Int(newValue)
+                                if level == 0 {
+                                    let settings = EnhancedBass(isEnabled: false, level: 1)
+                                    setEnhancedBassSettings(settings)
+                                } else {
+                                    let settings = EnhancedBass(isEnabled: true, level: level)
+                                    setEnhancedBassSettings(settings)
+                                }
+                            }
+                        ),
+                        in: 0...5,
+                        step: 1
+                    )
+                    .tint(.accentColor)
+                    
+                    Text("Lv5")
+                        .font(.caption2)
                         .foregroundColor(.secondary)
                 }
             }
-
-            Spacer()
-
-            Toggle(
-                "",
-                isOn: .init(
-                    get: {
-                        deviceState.enhancedBass?.isEnabled ?? false
-                    },
-                    set: { isEnabled in
-                        let settings = EnhancedBass(
-                            isEnabled: isEnabled,
-                            level: deviceState.enhancedBass?.level ?? 1
-                        )
-                        setEnhancedBassSettings(settings)
-                    }
-                )
-            )
-            .toggleStyle(.switch)
-            .padding(.trailing, -8)
-            .scaleEffect(0.8)
+            .disabled(deviceState.enhancedBass == nil)
         }
-        .padding(.horizontal, 4)
     }
-
-    private func enhancedBassMenu(currentLevel: Int) -> some View {
-        Menu {
-            ForEach(1...5, id: \.self) { level in
-                Button {
-                    let settings = EnhancedBass(isEnabled: true, level: level)
-                    setEnhancedBassSettings(settings)
-                } label: {
-                    Text("Level \(level)") + (currentLevel == level ? Text(" ") + Text(Image(systemName: "checkmark")) : Text(""))
-                }
-            }
-        } label: {
-            Text(deviceState.enhancedBass?.displayValue ?? "Unknown")
-                .font(.footnote)
-                .foregroundColor(.secondary)
+    
+    private var enhancedBassValue: String {
+        guard let enhancedBass = deviceState.enhancedBass else {
+            return "N/A"
         }
-        .menuStyle(BorderlessButtonMenuStyle())
+        return enhancedBass.isEnabled ? "Level \(enhancedBass.level)" : "Off"
     }
 
     private var isCompatibleWithSpatialAudio: Bool {
@@ -115,6 +136,20 @@ struct BarAudioView: View {
         deviceState.enhancedBass = settings
 
         AppLogger.audio.uiSettingChanged("Enhanced Bass", value: settings.displayValue)
+    }
+
+    private var bassTitle: String {
+        guard let model = deviceState.model else {
+            return "Bass Enhancement"
+        }
+        
+        // Check if it's a headphone (over-ear) or earbuds (in-ear)
+        switch model {
+            case .headphone1, .headphoneA:
+                return "Bass Enhancement"
+            default:
+                return "Ultra Bass"
+        }
     }
 
 }

--- a/NothingBar/Features/Bar/Capabilities/BarNoiseCancellationView.swift
+++ b/NothingBar/Features/Bar/Capabilities/BarNoiseCancellationView.swift
@@ -70,12 +70,14 @@ struct BarNoiseCancellationView: View {
     
     @ViewBuilder
     private func levelPill(_ level: NoiseCancellationMode.Active, isSelected: Bool) -> some View {
-        RoundedRectangle(cornerRadius: 3)
-            .fill(isSelected ? Color.accentColor : Color.white.opacity(0.3))
-            .frame(height: 6)
-            .onTapGesture {
-                nothing.setNoiseCancellationMode(.active(level))
-            }
+        Button {
+            nothing.setNoiseCancellationMode(.active(level))
+        } label: {
+            RoundedRectangle(cornerRadius: 3)
+                .fill(isSelected ? Color.accentColor : Color.white.opacity(0.3))
+                .frame(height: 6)
+        }
+        .buttonStyle(.plain)
     }
 
     private var value: String {

--- a/NothingBar/Features/Bar/Capabilities/BarNoiseCancellationView.swift
+++ b/NothingBar/Features/Bar/Capabilities/BarNoiseCancellationView.swift
@@ -25,9 +25,28 @@ struct BarNoiseCancellationView: View {
             title: "Noise Cancellation",
             value: value
         ) {
-            HStack(alignment: .top, spacing: 8) {
-                ForEach(NoiseCancellationMode.allCases, id: \.self) { mode in
-                    noiseCancellationItem(mode)
+            VStack(alignment: .center, spacing: 12) {
+                // Main ANC modes as circles
+                HStack(alignment: .top, spacing: 8) {
+                    ForEach(NoiseCancellationMode.allCases, id: \.self) { mode in
+                        noiseCancellationItem(mode)
+                    }
+                }
+                
+                // Sub-levels for active mode with labels
+                if case .active(let activeMode) = currentMode {
+                    VStack(alignment: .center, spacing: 6) {
+                        HStack(spacing: 12) {
+                            ForEach(NoiseCancellationMode.Active.allCases, id: \.self) { level in
+                                VStack(spacing: 4) {
+                                    levelPill(level, isSelected: activeMode == level)
+                                    Text(level.displayName)
+                                        .font(.caption2)
+                                        .foregroundColor(.secondary)
+                                }
+                            }
+                        }
+                    }
                 }
             }
             .disabled(deviceState.noiseCancellationMode == nil)
@@ -40,40 +59,23 @@ struct BarNoiseCancellationView: View {
         ModeCircleView(
             image: mode.imageName,
             name: mode.displayName,
-            isActive: isActive
-        ) {
-            nothing.setNoiseCancellationMode(mode)
-            AppLogger.audio.uiSettingChanged("Noise Cancellation", value: mode)
-        } overlay: {
-            if case .active(let activeMode) = currentMode, isActive {
-                AnyView(noiseCancellationMenu(currentMode: activeMode))
-            } else {
-                AnyView(EmptyView())
-            }
-        }
+            isActive: isActive,
+            onTap: {
+                nothing.setNoiseCancellationMode(mode)
+                AppLogger.audio.uiSettingChanged("Noise Cancellation", value: mode)
+            },
+            overlay: { EmptyView() }
+        )
     }
-
-    private func noiseCancellationMenu(currentMode: NoiseCancellationMode.Active) -> some View {
-        Menu {
-            ForEach(NoiseCancellationMode.Active.allCases, id: \.self) { mode in
-                Button {
-                    nothing.setNoiseCancellationMode(.active(mode))
-                } label: {
-                    Text(mode.displayName) + (currentMode == mode ? Text(" ") + Text(Image(systemName: "checkmark")) : Text(""))
-                }
+    
+    @ViewBuilder
+    private func levelPill(_ level: NoiseCancellationMode.Active, isSelected: Bool) -> some View {
+        RoundedRectangle(cornerRadius: 3)
+            .fill(isSelected ? Color.accentColor : Color.white.opacity(0.3))
+            .frame(height: 6)
+            .onTapGesture {
+                nothing.setNoiseCancellationMode(.active(level))
             }
-        } label: {
-            ZStack {
-                Circle()
-                    .fill(Color.gray)
-                    .frame(width: 20, height: 20)
-
-                Image(systemName: "chevron.down")
-                    .font(.caption)
-                    .foregroundColor(.white)
-                    .padding(8)
-            }
-        }
     }
 
     private var value: String {

--- a/NothingBar/Features/Bar/Notifications/BarNotificationAppleView.swift
+++ b/NothingBar/Features/Bar/Notifications/BarNotificationAppleView.swift
@@ -12,7 +12,7 @@ struct BarNotificationAppleView: View {
 
     @Environment(AppData.self) private var appData
 
-    private let iconSize = 28.0
+    private let iconSize = 36.0
 
     private var deviceState: DeviceState {
         appData.deviceState

--- a/NothingBar/Features/Bar/Notifications/BarNotificationClassicView.swift
+++ b/NothingBar/Features/Bar/Notifications/BarNotificationClassicView.swift
@@ -20,7 +20,7 @@ struct BarNotificationClassicView: View {
         HStack(spacing: 12) {
             if let deviceImage = deviceState.model?.deviceImage {
                 DeviceImageView(deviceImage: deviceImage)
-                    .frame(height: 32)
+                    .frame(height: 42)
             }
 
             VStack(alignment: .leading, spacing: 2) {

--- a/NothingBar/Features/Bar/Notifications/BarNotiticationCenter.swift
+++ b/NothingBar/Features/Bar/Notifications/BarNotiticationCenter.swift
@@ -50,8 +50,8 @@ final class BarNotificationCenter {
     private var entries: [NotificationEntry] = []
 
     private let hMargin: CGFloat = 16
-    private let classicTopMargin: CGFloat = 40
-    private let appleTopMargin: CGFloat = 8
+    private let classicTopMargin: CGFloat = 60
+    private let appleTopMargin: CGFloat = 24
     private let spacing: CGFloat = 10
 
     func show(with appData: AppData, duration: TimeInterval = 3.0, screen: NSScreen? = nil) {
@@ -60,7 +60,7 @@ final class BarNotificationCenter {
         let host = NSHostingView(rootView: view)
         host.translatesAutoresizingMaskIntoConstraints = false
         let panel = BarNotificationWindow(host: host)
-        panel.alphaValue = 0
+        panel.alphaValue = 1
 
         host.layoutSubtreeIfNeeded()
         let size = host.fittingSize
@@ -73,17 +73,20 @@ final class BarNotificationCenter {
             stackHeight: currentStackHeight(on: scr, style: style)
         )
 
+        // Start slightly higher than final position
+        let startOrigin = NSPoint(x: origin.x, y: origin.y + 20)
         panel.setFrame(
-            NSRect(x: origin.x, y: origin.y, width: size.width, height: size.height),
+            NSRect(x: startOrigin.x, y: startOrigin.y, width: size.width, height: size.height),
             display: true
         )
         panel.orderFrontRegardless()
 
+        // Animate sliding down from top with fade in
         NSAnimationContext.runAnimationGroup { ctx in
-            ctx.duration = 0.18
+            ctx.duration = 0.3
             ctx.timingFunction = .init(name: .easeOut)
             panel.animator().alphaValue = 1
-            panel.setFrameOrigin(origin)
+            panel.animator().setFrameOrigin(origin)
         }
 
         entries.append(.init(panel: panel, style: style))
@@ -102,11 +105,14 @@ final class BarNotificationCenter {
 
     private func dismiss(_ panel: BarNotificationWindow) {
         guard let idx = entries.firstIndex(where: { $0.panel === panel }) else { return }
+        
+        let exitOrigin = NSPoint(x: panel.frame.origin.x, y: panel.frame.origin.y + 20)
+        
         NSAnimationContext.runAnimationGroup { ctx in
-            ctx.duration = 0.18
+            ctx.duration = 0.3
             ctx.timingFunction = .init(name: .easeIn)
-            panel.animator().alphaValue = 0
-            panel.setFrameOrigin(NSPoint(x: panel.frame.origin.x, y: panel.frame.origin.y))
+            panel.animator().alphaValue = 0.7
+            panel.animator().setFrameOrigin(exitOrigin)
         } completionHandler: {
             panel.orderOut(nil)
             panel.close()

--- a/NothingBar/Features/Bar/Notifications/BarNotiticationCenter.swift
+++ b/NothingBar/Features/Bar/Notifications/BarNotiticationCenter.swift
@@ -60,7 +60,7 @@ final class BarNotificationCenter {
         let host = NSHostingView(rootView: view)
         host.translatesAutoresizingMaskIntoConstraints = false
         let panel = BarNotificationWindow(host: host)
-        panel.alphaValue = 1
+        panel.alphaValue = 0
 
         host.layoutSubtreeIfNeeded()
         let size = host.fittingSize
@@ -111,7 +111,7 @@ final class BarNotificationCenter {
         NSAnimationContext.runAnimationGroup { ctx in
             ctx.duration = 0.3
             ctx.timingFunction = .init(name: .easeIn)
-            panel.animator().alphaValue = 0.7
+            panel.animator().alphaValue = 0
             panel.animator().setFrameOrigin(exitOrigin)
         } completionHandler: {
             panel.orderOut(nil)

--- a/NothingBar/Features/Settings/Device/SettingsDeviceToolsView.swift
+++ b/NothingBar/Features/Settings/Device/SettingsDeviceToolsView.swift
@@ -39,13 +39,13 @@ struct SettingsDeviceToolsView: View {
             }
 
             SettingsRow(
-                title: "Over-ear detection",
+                title: detectionTitle,
                 description: "Automatically play audio when headphones are in and pause when removed"
             ) {
                 Toggle("", isOn: $bindableAppData.deviceState.inEarDetection)
                     .onChange(of: deviceState.inEarDetection) { _, isEnabled in
                         nothing.setInEarDetection(isEnabled)
-                        AppLogger.settings.uiSettingChanged("Over-ear Detection", value: isEnabled)
+                        AppLogger.settings.uiSettingChanged(detectionTitle, value: isEnabled)
                     }
                     .disabled(!deviceState.isConnected)
             }
@@ -113,6 +113,20 @@ struct SettingsDeviceToolsView: View {
     private func setRingBuds(_ ringBuds: RingBuds) {
         deviceState.ringBuds = ringBuds
         nothing.setRingBuds(ringBuds)
+    }
+
+    private var detectionTitle: String {
+        guard let model = deviceState.model else {
+            return "Detection"
+        }
+        
+        // Check if it's a headphone (over-ear) or earbuds (in-ear)
+        switch model {
+            case .headphone1, .headphoneA:
+                return "Over-ear detection"
+            default:
+                return "In-ear detection"
+        }
     }
 }
 

--- a/NothingBar/Models/AppData.swift
+++ b/NothingBar/Models/AppData.swift
@@ -20,6 +20,7 @@ class AppData {
 
     var deviceState: DeviceState
     var appVersion: AppVersion
+    var systemVolumeController: SystemVolumeController
 
     var showConnectNotifications: Bool = true
     var showBatteryNotifications: Bool = true
@@ -41,12 +42,15 @@ class AppData {
     var nothing: Device!
 
     private let batteryLowLevels = [20, 10, 5]
+    private var lastNotificationTime: Date = Date(timeIntervalSince1970: 0)
+    private let notificationDebounceInterval: TimeInterval = 0.3
 
     @MainActor
     init() {
         let defaults = UserDefaults.standard
         self.deviceState = DeviceState()
         self.appVersion = AppVersion()
+        self.systemVolumeController = SystemVolumeController()
         self.showConnectNotifications = defaults.object(forKey: Keys.showConnectNotifications) as? Bool ?? true
         self.showBatteryNotifications = defaults.object(forKey: Keys.showBatteryNotifications) as? Bool ?? true
         self.notificationStyle = NotificationStyle(
@@ -151,6 +155,8 @@ class AppData {
 
     @MainActor
     private func showBatteryLevelNotification(_ battery: Battery?) {
+        // Don't show battery notifications if device is disconnected
+        guard deviceState.isConnected else { return }
         guard showBatteryNotifications, let battery else { return }
 
         let needNotification = if let oldLevel = deviceState.battery?.level {
@@ -162,6 +168,10 @@ class AppData {
         }
 
         if needNotification {
+            let now = Date()
+            guard now.timeIntervalSince(lastNotificationTime) >= notificationDebounceInterval else { return }
+            
+            lastNotificationTime = now
             BarNotificationCenter.shared.show(with: self)
         }
     }
@@ -169,7 +179,11 @@ class AppData {
     @MainActor
     private func showNotification() {
         guard showConnectNotifications else { return }
-
+        
+        let now = Date()
+        guard now.timeIntervalSince(lastNotificationTime) >= notificationDebounceInterval else { return }
+        
+        lastNotificationTime = now
         BarNotificationCenter.shared.show(with: self)
     }
 }

--- a/NothingBar/Utils/StatusBarController.swift
+++ b/NothingBar/Utils/StatusBarController.swift
@@ -1,4 +1,5 @@
 import AppKit
+import SwiftNothingEar
 import SwiftUI
 
 @MainActor
@@ -55,7 +56,7 @@ final class StatusBarController: NSObject {
 
         restoreStatusItemPosition()
         insertStatusItemIfNeeded()
-        updateStatusImage(isConnected: isConnected)
+        updateStatusImage(isConnected: isConnected, model: appData.deviceState.model)
         updatePanelFrame()
     }
 
@@ -226,13 +227,74 @@ final class StatusBarController: NSObject {
         statusItem = newStatusItem
     }
 
-    private func updateStatusImage(isConnected: Bool) {
+    private func updateStatusImage(isConnected: Bool, model: DeviceModel?) {
         guard let button = statusItem?.button else { return }
 
-        let symbolName = isConnected ? "headphones" : "headphones.slash"
-        let image = NSImage(systemSymbolName: symbolName, accessibilityDescription: "Nothing Headphones")
-        image?.isTemplate = true
-        button.image = image
+        if isConnected, let deviceImage = model?.deviceImage {
+            let size = NSSize(width: 36, height: 18)
+            if let nsImage = renderDeviceImageToNSImage(deviceImage, size: size) {
+                button.image = nsImage
+                return
+            }
+        }
+        
+        if isConnected {
+            let symbolName = "headphones"
+            let image = NSImage(systemSymbolName: symbolName, accessibilityDescription: "Nothing Headphones")
+            image?.isTemplate = true
+            button.image = image
+        } else {
+            let symbolName = "headphones.slash"
+            let image = NSImage(systemSymbolName: symbolName, accessibilityDescription: "Nothing Headphones Disconnected")
+            image?.isTemplate = true
+            button.image = image
+        }
+    }
+
+    private func renderDeviceImageToNSImage(_ deviceImage: DeviceModel.DeviceImage, size: NSSize) -> NSImage? {
+        let contentView: AnyView = switch deviceImage {
+            case .buds(let left, let right):
+                AnyView(
+                    HStack(spacing: 0) {
+                        Image(left)
+                            .resizable()
+                            .interpolation(.high)
+                            .aspectRatio(contentMode: .fit)
+                        Image(right)
+                            .resizable()
+                            .interpolation(.high)
+                            .aspectRatio(contentMode: .fit)
+                    }
+                )
+            case .single(let image):
+                AnyView(
+                    Image(image)
+                        .resizable()
+                        .interpolation(.high)
+                        .aspectRatio(contentMode: .fit)
+                )
+        }
+        
+        return renderSwiftUIImageToNSImage(contentView, size: size)
+    }
+
+    private func renderSwiftUIImageToNSImage(_ view: AnyView, size: NSSize) -> NSImage? {
+        let hostingController = NSHostingController(rootView: view
+            .frame(width: size.width, height: size.height)
+        )
+        
+        let nsView = hostingController.view
+        nsView.frame.size = size
+        
+        guard let bitmapImage = nsView.bitmapImageRepForCachingDisplay(in: nsView.bounds) else {
+            return nil
+        }
+        
+        nsView.cacheDisplay(in: nsView.bounds, to: bitmapImage)
+        
+        let nsImage = NSImage(size: size)
+        nsImage.addRepresentation(bitmapImage)
+        return nsImage
     }
 }
 

--- a/NothingBar/Utils/SystemVolumeController.swift
+++ b/NothingBar/Utils/SystemVolumeController.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+@Observable
+class SystemVolumeController {
+    
+    var volume: Float = 0.5 {
+        didSet {
+            setSystemVolume(volume)
+        }
+    }
+    
+    private var volumeUpdateTimer: Timer?
+    
+    init() {
+        self.volume = getSystemVolume()
+        startVolumeMonitoring()
+    }
+    
+    func getSystemVolume() -> Float {
+        let task = Process()
+        task.launchPath = "/usr/bin/osascript"
+        task.arguments = ["-e", "output volume of (get volume settings)"]
+        
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        
+        do {
+            try task.run()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            if let volumeString = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+               let volumeInt = Int(volumeString) {
+                return Float(volumeInt) / 100.0
+            }
+        } catch {
+            print("Failed to get system volume: \(error)")
+        }
+        
+        return 0.5
+    }
+    
+    private func setSystemVolume(_ volume: Float) {
+        let clampedVolume = max(0.0, min(1.0, volume))
+        let volumePercent = Int(clampedVolume * 100)
+        
+        let script = "set volume output volume \(volumePercent)"
+        let task = Process()
+        task.launchPath = "/usr/bin/osascript"
+        task.arguments = ["-e", script]
+        
+        do {
+            try task.run()
+        } catch {
+            print("Failed to set system volume: \(error)")
+        }
+    }
+    
+    private func startVolumeMonitoring() {
+        // Poll system volume every 0.5 seconds to stay in sync
+        volumeUpdateTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
+            DispatchQueue.main.async {
+                let currentVolume = self?.getSystemVolume() ?? 0.5
+                if abs(currentVolume - (self?.volume ?? 0.5)) > 0.01 {
+                    self?.volume = currentVolume
+                }
+            }
+        }
+    }
+    
+    deinit {
+        volumeUpdateTimer?.invalidate()
+    }
+}
+


### PR DESCRIPTION
- Fix duplicate notifications on disconnect when battery levels mismatch
- Add 0.3s debounce to connection and battery notifications
- Implement system volume control with real-time polling
- Display device-specific earbud icons in menu bar
- Remove focus rings from all interactive elements
- Enhance notification animations (slide from top, easeOut/easeIn)
- Increase notification top margins for better spacing
- Enlarge earbud icons in notifications (32→42px classic, 28→36px apple)
- Improve battery display with individual levels per earbud
- Add level pills for ANC sub-modes with labels
- Redesign enhanced bass UI with slider control
- Adaptive labels for headphones vs earbuds (detection, bass)
- Revert code signing identity to 'Apple Development'

<img width="597" height="68" alt="Screenshot 2026-03-29 at 11 31 57 PM" src="https://github.com/user-attachments/assets/1e26fd02-1926-42ab-8731-1f021efc49a7" />
<img width="325" height="553" alt="Screenshot 2026-03-29 at 11 32 25 PM" src="https://github.com/user-attachments/assets/6d87cbad-35bb-4c76-b047-f488dffcdfa9" />
<img width="303" height="154" alt="Screenshot 2026-03-29 at 11 32 44 PM" src="https://github.com/user-attachments/assets/32e4f1c9-ee65-4fd5-b19b-7299dafa27b0" />
