### PR TITLE
Tighten up bar UI and battery/status layout

### DIFF
--- a/NothingBar/Features/Bar/BarHeaderView.swift
+++ b/NothingBar/Features/Bar/BarHeaderView.swift
@@ -20,38 +20,129 @@ struct BarHeaderView: View {
     var body: some View {
         HStack(spacing: 8) {
             if let deviceImage = deviceState.model?.deviceImage {
-                DeviceImageView(deviceImage: deviceImage)
-                    .frame(height: 32)
+                deviceImageView(deviceImage)
             } else {
                 Image(systemName: "headphones")
-                    .font(.system(size: 24))
+                    .font(.system(size: 20))
                     .foregroundColor(.primary)
             }
 
             titleView
-
-            Spacer()
 
             BarSettingsButton()
         }
         .padding(.horizontal, 4)
     }
 
+    @ViewBuilder
+    private func deviceImageView(_ deviceImage: DeviceModel.DeviceImage) -> some View {
+        switch deviceImage {
+            case let .buds(left, right):
+                HStack(spacing: 2) {
+                    Image(left)
+                        .resizable()
+                        .interpolation(.high)
+                        .aspectRatio(contentMode: .fit)
+                        .frame(height: 26)
+
+                    Image(right)
+                        .resizable()
+                        .interpolation(.high)
+                        .aspectRatio(contentMode: .fit)
+                        .frame(height: 26)
+                }
+                .frame(minWidth: 32)
+            case let .single(image):
+                Image(image)
+                    .resizable()
+                    .interpolation(.high)
+                    .aspectRatio(contentMode: .fit)
+                    .frame(height: 26)
+                    .frame(minWidth: 32)
+        }
+    }
+
     private var titleView: some View {
-        VStack(alignment: .leading, spacing: 2) {
+        VStack(alignment: .leading, spacing: 3) {
             Text(deviceState.model?.displayName ?? "Unknown")
                 .font(.headline)
                 .foregroundColor(.primary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
 
-            if deviceState.isConnected {
-                if let battery = deviceState.battery {
-                    BatteryView(battery: battery)
-                }
-            } else {
+            if deviceState.isConnected, let battery = deviceState.battery {
+                batterySummaryView(battery)
+            } else if !deviceState.isConnected {
                 Text("Disconnected")
-                    .font(.subheadline)
+                    .font(.caption)
                     .foregroundColor(.secondary)
             }
         }
+    }
+
+    @ViewBuilder
+    private func batterySummaryView(_ battery: Battery) -> some View {
+        switch battery {
+            case .budsWithCase(let `case`, let leftBud, let rightBud):
+                batterySummaryRow(leftBud: leftBud, caseBattery: `case`, rightBud: rightBud)
+                    .font(.caption2)
+            case .single(let singleBattery):
+                batterySummaryItem(title: nil, level: singleBattery)
+                    .font(.caption2)
+        }
+    }
+
+    private func batterySummaryRow(
+        leftBud: BatteryLevel,
+        caseBattery: BatteryLevel,
+        rightBud: BatteryLevel
+    ) -> some View {
+        HStack(spacing: 5) {
+            batterySummaryItem(title: "L", level: leftBud)
+            batterySummaryItem(title: "C", level: caseBattery)
+            batterySummaryItem(title: "R", level: rightBud)
+        }
+        .fixedSize(horizontal: true, vertical: false)
+    }
+
+    @ViewBuilder
+    private func batterySummaryItem(title: String?, level: BatteryLevel) -> some View {
+        if level.isConnected {
+            HStack(spacing: 2) {
+                if let title {
+                    Text(title)
+                        .foregroundColor(.secondary)
+                }
+
+                Image(systemName: batteryIcon(for: level.level, isCharging: level.isCharging))
+                    .foregroundColor(batteryColor(for: level.level, isCharging: level.isCharging))
+
+                Text("\(level.level)%")
+                    .foregroundColor(.secondary)
+            }
+            .fixedSize(horizontal: true, vertical: false)
+        }
+    }
+
+    private func batteryIcon(for level: Int, isCharging: Bool) -> String {
+        guard !isCharging else {
+            return "battery.100.bolt"
+        }
+
+        switch level {
+            case 81...100: return "battery.100"
+            case 61...80: return "battery.75"
+            case 41...60: return "battery.50"
+            case 21...40: return "battery.25"
+            default: return "battery.0"
+        }
+    }
+
+    private func batteryColor(for level: Int, isCharging: Bool) -> Color {
+        guard !isCharging else {
+            return .secondary
+        }
+
+        return level <= 20 ? .red : .secondary
     }
 }

--- a/NothingBar/Features/Bar/Capabilities/BarAudioView.swift
+++ b/NothingBar/Features/Bar/Capabilities/BarAudioView.swift
@@ -22,72 +22,58 @@ struct BarAudioView: View {
 
     var body: some View {
         VStack(spacing: 12) {
+            BarAudioEQView()
+                .disabled(deviceState.eqPreset == nil)
             if let model = deviceState.model, model.supportsEnhancedBass {
                 enhancedBassView
                     .disabled(deviceState.enhancedBass == nil)
             }
-
-            BarAudioEQView()
-                .disabled(deviceState.eqPreset == nil)
         }
     }
-
-    // MARK: Enhanced Bass
 
     private var enhancedBassView: some View {
         HStack {
             VStack(alignment: .leading, spacing: 4) {
-                Text("Bass Enhancement")
+                Text(bassTitle)
                     .font(.subheadline)
                     .foregroundColor(.primary)
 
-                if let enhancedBass = deviceState.enhancedBass, enhancedBass.isEnabled {
-                    enhancedBassMenu(currentLevel: enhancedBass.level)
-                        .fixedSize()
-                        .padding(.leading, -4)
-                } else {
-                    Text("Off")
-                        .font(.footnote)
-                        .foregroundColor(.secondary)
-                }
+                enhancedBassMenu
+                    .fixedSize()
+                    .padding(.leading, -4)
             }
 
             Spacer()
-
-            Toggle(
-                "",
-                isOn: .init(
-                    get: {
-                        deviceState.enhancedBass?.isEnabled ?? false
-                    },
-                    set: { isEnabled in
-                        let settings = EnhancedBass(
-                            isEnabled: isEnabled,
-                            level: deviceState.enhancedBass?.level ?? 1
-                        )
-                        setEnhancedBassSettings(settings)
-                    }
-                )
-            )
-            .toggleStyle(.switch)
-            .padding(.trailing, -8)
-            .scaleEffect(0.8)
         }
         .padding(.horizontal, 4)
     }
 
-    private func enhancedBassMenu(currentLevel: Int) -> some View {
+    private var enhancedBassValue: String {
+        guard let enhancedBass = deviceState.enhancedBass else {
+            return "N/A"
+        }
+
+        return enhancedBass.isEnabled ? "Level \(enhancedBass.level)" : "Off"
+    }
+
+    private var enhancedBassMenu: some View {
         Menu {
+            Button {
+                setEnhancedBassSettings(.init(isEnabled: false, level: 1))
+            } label: {
+                Text("Off") + (enhancedBassValue == "Off" ? Text(" ") + Text(Image(systemName: "checkmark")) : Text(""))
+            }
+
             ForEach(1...5, id: \.self) { level in
                 Button {
-                    let settings = EnhancedBass(isEnabled: true, level: level)
-                    setEnhancedBassSettings(settings)
+                    setEnhancedBassSettings(.init(isEnabled: true, level: level))
                 } label: {
-                    Text("Level \(level)") + (currentLevel == level ? Text(" ") + Text(Image(systemName: "checkmark")) : Text(""))
+                    let isSelected = deviceState.enhancedBass?.isEnabled == true && deviceState.enhancedBass?.level == level
+                    Text("Level \(level)") + (isSelected ? Text(" ") + Text(Image(systemName: "checkmark")) : Text(""))
                 }
             }
         } label: {
-            Text(deviceState.enhancedBass?.displayValue ?? "Unknown")
+            Text(enhancedBassValue)
                 .font(.footnote)
                 .foregroundColor(.secondary)
         }
@@ -117,6 +103,19 @@ struct BarAudioView: View {
         AppLogger.audio.uiSettingChanged("Enhanced Bass", value: settings.displayValue)
     }
 
+    private var bassTitle: String {
+        guard let model = deviceState.model else {
+            return "Bass Enhancement"
+        }
+        
+        // Check if it's a headphone (over-ear) or earbuds (in-ear)
+        switch model {
+            case .headphone1, .headphoneA, .cmfHeadphonePro:
+                return "Bass Enhancement"
+            default:
+                return "Ultra Bass"
+        }
+    }
 }
 
 private extension EnhancedBass {

--- a/NothingBar/Features/Bar/Capabilities/BarNoiseCancellationView.swift
+++ b/NothingBar/Features/Bar/Capabilities/BarNoiseCancellationView.swift
@@ -25,9 +25,26 @@ struct BarNoiseCancellationView: View {
             title: "Noise Cancellation",
             value: value
         ) {
-            HStack(alignment: .top, spacing: 8) {
-                ForEach(NoiseCancellationMode.allCases, id: \.self) { mode in
-                    noiseCancellationItem(mode)
+            VStack(alignment: .center, spacing: 12) {
+                HStack(alignment: .top, spacing: 8) {
+                    ForEach(NoiseCancellationMode.allCases, id: \.self) { mode in
+                        noiseCancellationItem(mode)
+                    }
+                }
+
+                if case .active(let activeMode) = currentMode {
+                    VStack(alignment: .center, spacing: 6) {
+                        HStack(spacing: 12) {
+                            ForEach(NoiseCancellationMode.Active.allCases, id: \.self) { level in
+                                VStack(spacing: 4) {
+                                    levelPill(level, isSelected: activeMode == level)
+                                    Text(level.displayName)
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                }
+                            }
+                        }
+                    }
                 }
             }
             .disabled(deviceState.noiseCancellationMode == nil)
@@ -40,40 +57,25 @@ struct BarNoiseCancellationView: View {
         ModeCircleView(
             image: mode.imageName,
             name: mode.displayName,
-            isActive: isActive
-        ) {
-            nothing.setNoiseCancellationMode(mode)
-            AppLogger.audio.uiSettingChanged("Noise Cancellation", value: mode)
-        } overlay: {
-            if case .active(let activeMode) = currentMode, isActive {
-                AnyView(noiseCancellationMenu(currentMode: activeMode))
-            } else {
-                AnyView(EmptyView())
-            }
-        }
+            isActive: isActive,
+            onTap: {
+                nothing.setNoiseCancellationMode(mode)
+                AppLogger.audio.uiSettingChanged("Noise Cancellation", value: mode)
+            },
+            overlay: { EmptyView() }
+        )
     }
 
-    private func noiseCancellationMenu(currentMode: NoiseCancellationMode.Active) -> some View {
-        Menu {
-            ForEach(NoiseCancellationMode.Active.allCases, id: \.self) { mode in
-                Button {
-                    nothing.setNoiseCancellationMode(.active(mode))
-                } label: {
-                    Text(mode.displayName) + (currentMode == mode ? Text(" ") + Text(Image(systemName: "checkmark")) : Text(""))
-                }
-            }
+    @ViewBuilder
+    private func levelPill(_ level: NoiseCancellationMode.Active, isSelected: Bool) -> some View {
+        Button {
+            nothing.setNoiseCancellationMode(.active(level))
         } label: {
-            ZStack {
-                Circle()
-                    .fill(Color.gray)
-                    .frame(width: 20, height: 20)
-
-                Image(systemName: "chevron.down")
-                    .font(.caption)
-                    .foregroundColor(.white)
-                    .padding(8)
-            }
+            RoundedRectangle(cornerRadius: 3)
+                .fill(isSelected ? Color.accentColor : Color.secondary)
+                .frame(height: 6)
         }
+        .buttonStyle(.plain)
     }
 
     private var value: String {

--- a/NothingBar/Features/Bar/Notifications/BarNotificationClassicView.swift
+++ b/NothingBar/Features/Bar/Notifications/BarNotificationClassicView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct BarNotificationClassicView: View {
 
     @Environment(AppData.self) private var appData
+    private let iconSize = 36.0
 
     private var deviceState: DeviceState {
         appData.deviceState
@@ -20,37 +21,48 @@ struct BarNotificationClassicView: View {
         HStack(spacing: 12) {
             if let deviceImage = deviceState.model?.deviceImage {
                 DeviceImageView(deviceImage: deviceImage)
-                    .frame(height: 32)
+                    .frame(width: iconSize, height: iconSize)
             }
 
             VStack(alignment: .leading, spacing: 2) {
                 if let displayName = deviceState.model?.displayName {
                     Text(displayName)
-                        .font(.headline)
+                        .font(.system(size: 12, weight: .medium))
                         .foregroundColor(.primary)
+                        .multilineTextAlignment(.leading)
                 }
 
                 Text(deviceState.isConnected ? "Connected" : "Disconnected")
-                    .font(.body)
+                    .font(.system(size: 11, weight: .regular))
                     .foregroundColor(.secondary)
             }
-            .frame(maxWidth: 200)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .layoutPriority(1)
 
             BarNotificationRingView(
                 progress: batteryProgress,
                 isConnected: deviceState.isConnected,
-                size: .medium
+                size: .small
             )
         }
-        .padding(16)
+        .frame(maxWidth: 300)
+        .padding(10)
         .background {
             if #available(macOS 26.0, *) {
                 Capsule()
                     .fill(.regularMaterial.opacity(0.3))
+                    .overlay {
+                        Capsule()
+                            .strokeBorder(.white.opacity(0.12), lineWidth: 1)
+                    }
                     .glassEffect(.regular)
             } else {
                 Capsule()
                     .fill(.regularMaterial)
+                    .overlay {
+                        Capsule()
+                            .strokeBorder(.white.opacity(0.12), lineWidth: 1)
+                    }
             }
         }
     }

--- a/NothingBar/Features/Settings/Device/SettingsDeviceHeaderView.swift
+++ b/NothingBar/Features/Settings/Device/SettingsDeviceHeaderView.swift
@@ -45,13 +45,101 @@ struct SettingsDeviceHeaderView: View {
 
     private var subtitleView: some View {
         HStack(spacing: 6) {
+            if deviceState.isConnected {
+                Circle()
+                    .fill(.green)
+                    .frame(width: 7, height: 7)
+            }
+
             Text(deviceState.isConnected ? "Connected" : "Disconnected")
                 .font(.subheadline)
                 .foregroundColor(.secondary)
 
             if let battery = deviceState.battery, deviceState.isConnected {
-                BatteryView(battery: battery)
+                batterySummaryView(battery)
             }
         }
+    }
+
+    @ViewBuilder
+    private func batterySummaryView(_ battery: Battery) -> some View {
+        switch battery {
+            case .budsWithCase(let `case`, let leftBud, let rightBud):
+                ViewThatFits(in: .horizontal) {
+                    batterySummaryRow(leftBud: leftBud, caseBattery: `case`, rightBud: rightBud, spacing: 8)
+                        .font(.subheadline)
+
+                    batterySummaryRow(leftBud: leftBud, caseBattery: `case`, rightBud: rightBud, spacing: 6)
+                        .font(.caption)
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        HStack(spacing: 8) {
+                            batterySummaryItem(title: "L", level: leftBud)
+                            batterySummaryItem(title: "C", level: `case`)
+                        }
+
+                        HStack(spacing: 8) {
+                            batterySummaryItem(title: "R", level: rightBud)
+                        }
+                    }
+                    .font(.caption)
+                }
+            case .single(let singleBattery):
+                batterySummaryItem(title: "Battery", level: singleBattery)
+                    .font(.subheadline)
+        }
+    }
+
+    private func batterySummaryRow(
+        leftBud: BatteryLevel,
+        caseBattery: BatteryLevel,
+        rightBud: BatteryLevel,
+        spacing: CGFloat
+    ) -> some View {
+        HStack(spacing: spacing) {
+            batterySummaryItem(title: "L", level: leftBud)
+            batterySummaryItem(title: "C", level: caseBattery)
+            batterySummaryItem(title: "R", level: rightBud)
+        }
+        .fixedSize(horizontal: true, vertical: false)
+    }
+
+    @ViewBuilder
+    private func batterySummaryItem(title: String, level: BatteryLevel) -> some View {
+        if level.isConnected {
+            HStack(spacing: 4) {
+                Text(title)
+                    .foregroundColor(.secondary)
+
+                Image(systemName: batteryIcon(for: level.level, isCharging: level.isCharging))
+                    .foregroundColor(batteryColor(for: level.level, isCharging: level.isCharging))
+
+                Text("\(level.level)%")
+                    .foregroundColor(.secondary)
+            }
+            .fixedSize(horizontal: true, vertical: false)
+        }
+    }
+
+    private func batteryIcon(for level: Int, isCharging: Bool) -> String {
+        guard !isCharging else {
+            return "battery.100.bolt"
+        }
+
+        switch level {
+            case 81...100: return "battery.100"
+            case 61...80: return "battery.75"
+            case 41...60: return "battery.50"
+            case 21...40: return "battery.25"
+            default: return "battery.0"
+        }
+    }
+
+    private func batteryColor(for level: Int, isCharging: Bool) -> Color {
+        guard !isCharging else {
+            return .secondary
+        }
+
+        return level <= 20 ? .red : .secondary
     }
 }


### PR DESCRIPTION
## What changed

This cleans up the bar UI based on the review feedback and makes the layout feel a bit more compact overall.

Main updates:
- made the bar header more compact
- moved battery info into a cleaner inline layout in the header
- show buds battery as 
- added battery icons to the inline battery display
- low battery icons turn red at  and below
- updated the device settings header to use the same battery row style
- added a green dot next to  in device settings
- changed ANC sub-level labels to 
- changed the unselected ANC pill color to 
- removed the volume section from the bar for now
- toned down Ultra Bass / Bass Enhancement so it doesn't stand out as much
- reduced the size of the classic notification pill

## Notes

Kept this PR focused on the compactness/consistency feedback only.

Menu bar icon changes are being handled separately.

## Validation

Built with:

/Users/diludevx/projects/swift/nothing-bar/NothingBar.xcodeproj: error: Signing for "NothingBar" requires a development team. Select a development team in the Signing & Capabilities editor. (in target 'NothingBar' from project 'NothingBar')